### PR TITLE
Set Run on Schedule via Import / Export

### DIFF
--- a/backend/controller/models.py
+++ b/backend/controller/models.py
@@ -318,6 +318,7 @@ class Pipeline(extensions.db.Model):
       mailers.NotificationMailer().finished_pipeline(self)
 
   def import_data(self, data):
+    self.run_on_schedule = data.get('run_on_schedule', False)
     self.assign_params(data['params'])
     self.assign_schedules(data['schedules'])
     job_mapping = {}

--- a/backend/controller/pipeline/views.py
+++ b/backend/controller/pipeline/views.py
@@ -204,6 +204,7 @@ class PipelineExport(Resource):
 
     data = {
         'name': pipeline.name,
+        'run_on_schedule': pipeline.run_on_schedule,
         'jobs': jobs,
         'params': pipeline_params,
         'schedules': pipeline_schedules


### PR DESCRIPTION
- Add an additional parameter to the JSON import & export files to indicate whether the pipeline should be set to run on schedule.
- If a JSON template is correctly formatted without the run on schedule flag, CRMint will still interpret the file and will set it to False by default.
- During export, the run_on_schedule parameter will be set according to the current setting.