### PR TITLE
Add SQL Policy checks during deployment

### DIFF
--- a/cli/commands/cloud.py
+++ b/cli/commands/cloud.py
@@ -295,7 +295,8 @@ def check_billing_enabled(stage: shared.StageContext,
 
 def check_sql_instance_policy_restrictions(stage: shared.StageContext,
                                            debug: bool = False) -> bool:
-  """Returns True if no project-level or inherited policies restrict the use of public IPs for Cloud SQL.
+  """Returns True if no project-level or inherited policies restrict the use 
+  of public IPs for Cloud SQL.
 
   Args:
     stage: Stage context.
@@ -325,9 +326,11 @@ def check_sql_instance_policy_restrictions(stage: shared.StageContext,
       enforced = policy_data.get("booleanPolicy", {}).get("enforced", False)
 
       if enforced:
-        return False, f'Policy "{policy}" is enforced. Cloud SQL instances with public IPs are restricted.'
+        return False, (f'Policy "{policy}" is enforced. Cloud SQL instances '
+                       'with public IPs are restricted.')
     except json.JSONDecodeError:
-      return False, f'Failed to parse policy {policy}. Check organization-level policies manually.'
+      return False, (f'Failed to parse policy {policy}. Check organization-'
+                     'level policies manually.')
   return True, ''
 
 

--- a/cli/commands/cloud.py
+++ b/cli/commands/cloud.py
@@ -307,7 +307,7 @@ def check_sql_instance_policy_restrictions(stage: shared.StageContext,
       'constraints/sql.restrictPublicIp',
   ]
 
-  for policy in policies_to_check:
+  for idx, policy in enumerate(policies_to_check):
     cmd = textwrap.dedent(f"""\
         {GCLOUD} resource-manager org-policies describe {policy} \\
             --project={project_id} \\
@@ -315,7 +315,10 @@ def check_sql_instance_policy_restrictions(stage: shared.StageContext,
             --format="json"
     """)
     _, out, _ = shared.execute_command(
-        f'Checking effective policy {policy}', cmd, debug=debug, debug_uses_std_out=False)
+        f'Checking Cloud SQL policy ({idx + 1}/{len(policies_to_check)})',
+        cmd,
+        debug=debug,
+        debug_uses_std_out=False)
 
     try:
       policy_data = json.loads(out)
@@ -1223,7 +1226,6 @@ def checklist(stage_path: Union[None, str], debug: bool) -> None:
         """), _INDENT_PREFIX), fg='red', bold=True)
     sys.exit(1)
 
-  click.echo(click.style('---> Checking Cloud SQL policies', fg='cyan', bold=False))
   success, message = check_sql_instance_policy_restrictions(stage, debug=debug)
   if not success:
     click.secho(textwrap.indent(message, _INDENT_PREFIX), fg='red', bold=True)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,7 +122,7 @@ function install_command_line() {
   sudo apt-get update
   sudo apt-get install -y software-properties-common
   sudo add-apt-repository ppa:deadsnakes/ppa -y &> /dev/null
-  sudo apt-get update
+  sudo apt-get update -qq
   sudo apt-get install -y -qq python3.9 python3.9-venv python3.9-dev
 
   # Verify Python 3.9 installation

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,7 @@ function install_command_line() {
 
   # Proceed to install the cli package
   echo "Installing CRMint CLI package..."
-  pip install --quiet -e cli/
+  pip install --quiet --config-settings editable_mode=compat -e cli/
 }
 
 # Function to add wrapper function to .bashrc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,8 +121,8 @@ function install_command_line() {
   echo "Installing Python 3.9 and necessary packages..."
   sudo apt-get update
   sudo apt-get install -y software-properties-common
-  sudo add-apt-repository ppa:deadsnakes/ppa -y
-  sudo apt-get update -qq
+  sudo add-apt-repository ppa:deadsnakes/ppa -y &> /dev/null
+  sudo apt-get update
   sudo apt-get install -y -qq python3.9 python3.9-venv python3.9-dev
 
   # Verify Python 3.9 installation

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,7 +121,7 @@ function install_command_line() {
   echo "Installing Python 3.9 and necessary packages..."
   sudo apt-get update
   sudo apt-get install -y software-properties-common
-  sudo add-apt-repository ppa:deadsnakes/ppa -y &> /dev/null
+  sudo add-apt-repository ppa:deadsnakes/ppa -y
   sudo apt-get update -qq
   sudo apt-get install -y -qq python3.9 python3.9-venv python3.9-dev
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,10 +103,10 @@ function clone_and_checkout_repository() {
     sudo git clean -fdx || echo "Warning: Some files could not be removed. You may need to manually remove files with elevated permissions."
     git checkout $TARGET_BRANCH
   else
-    git clone "$TARGET_REPO_URL" "$CLONE_DIR" --quiet
+    git clone "$TARGET_REPO_URL" "$CLONE_DIR"
     echo "Cloned $TARGET_REPO_NAME repository to your home directory: $HOME."
     cd "$CLONE_DIR"
-    git checkout $TARGET_BRANCH --quiet
+    git checkout $TARGET_BRANCH
   fi
 }
 
@@ -119,8 +119,8 @@ function install_command_line() {
 
   # Install Python 3.9 and its venv module
   echo "Installing Python 3.9 and necessary packages..."
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq software-properties-common
+  sudo apt-get update
+  sudo apt-get install -y software-properties-common
   sudo add-apt-repository ppa:deadsnakes/ppa -y &> /dev/null
   sudo apt-get update -qq
   sudo apt-get install -y -qq python3.9 python3.9-venv python3.9-dev


### PR DESCRIPTION
 - Added checks for restrictAuthorizedNetworks and restrictPublicIp policies to prevent downstream errors when attempting to create a Cloud SQL instance with a public IP by default during App Engine deployment. This ensures that organizational policies are validated early in the process, reducing the risk of policy-related deployment failures.
 - Improved install.sh to enhance logging clarity and streamline the output. Removed unnecessary deprecation warnings and ensured the installation process is smoother, particularly when installing Python 3.9 and related packages for CRMint.